### PR TITLE
fix: rename library->bibliotheca leftovers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ CHANGELOG
 6.1.0-7 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Add ``scripts/`` helpers to repair items created before the
+  ``library.*`` -> ``bibliotheca.*`` rename: ``fix_rename.py`` (rewrite stale
+  FTI schema strings, purge orphaned browser layers, register the renamed
+  layers) and ``realign_profiles.py`` (re-align GenericSetup profile versions).
+  Run with ``bin/instance run scripts/<name>.py``.
+  [remdub]
 
 
 6.1.0-6 (2026-07-13)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,26 @@ CHANGELOG
   Run with ``bin/instance run scripts/<name>.py``.
   [remdub]
 
+- bibliotheca.policy 3.1.2
+
+  - Add upgrade step (1017 -> 1018) to fix ``library.*`` -> ``bibliotheca.*`` rename
+    artifacts left in existing ZODBs: rewrite the stale ``patrimoine`` FTI schema
+    string (fixes a ``RecursionError`` on ``lookupSchema``), purge the orphaned
+    ``ILibraryCoreLayer`` / ``ILibraryPolicyLayer`` browser layers, and register
+    the renamed ``IBibliothecaCoreLayer`` / ``IBibliothecaPolicyLayer`` layers so
+    views/viewlets/tiles bound to them (e.g. the ``existingcontent`` tile) work.
+    [remdub]
+
+- bibliotheca.policy 3.1.1
+
+  - Rename to bibliotheca.policy
+    [bsuttor]
+
+- bibliotheca.core 3.0.1
+
+  - Rename to bibliotheca.core 
+    [bsuttor]
+
 
 6.1.0-6 (2026-07-13)
 --------------------

--- a/scripts/fix_rename.py
+++ b/scripts/fix_rename.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+"""Offline repair for the library.* -> bibliotheca.* rename.
+
+Run with:  bin/instance run scripts/fix_rename.py
+
+The existing ZODB was populated while the add-ons were named library.*.
+After the rename to bibliotheca.* those dotted names are no longer importable,
+which breaks:
+  * the persisted patrimoine FTI schema string  -> RecursionError on lookupSchema
+  * the plone.browserlayer local utility (ILibraryCoreLayer) -> startup warning
+
+This script rewrites the stale references in place and commits.
+"""
+import transaction
+from Acquisition import aq_base
+from zope.component.hooks import setSite
+
+OLD_PREFIX = "library."
+NEW_PREFIX = "bibliotheca."
+
+
+def iter_plone_sites(app):
+    for obj in app.objectValues():
+        # A Plone site has a portal_types tool; good enough and avoids imports.
+        if getattr(aq_base(obj), "portal_types", None) is not None:
+            yield obj
+
+
+def fix_ftis(site):
+    changed = []
+    ptypes = site.portal_types
+    for type_id in ptypes.objectIds():
+        fti = ptypes[type_id]
+        for attr in ("schema", "model_source"):
+            value = getattr(fti, attr, None)
+            if value and OLD_PREFIX in value:
+                new_value = value.replace(OLD_PREFIX, NEW_PREFIX)
+                setattr(fti, attr, new_value)
+                changed.append((type_id, attr, value, new_value))
+    return changed
+
+
+def invalidate_schema_cache(changed):
+    try:
+        from plone.dexterity.schema import SCHEMA_CACHE
+    except Exception as exc:  # pragma: no cover
+        print("  ! could not import SCHEMA_CACHE: %s" % exc)
+        return
+    for type_id, attr, _old, _new in changed:
+        if attr in ("schema", "model_source"):
+            try:
+                SCHEMA_CACHE.invalidate(type_id)
+            except Exception as exc:
+                print("  ! invalidate(%s) failed: %s" % (type_id, exc))
+    # Also clear the whole cache to be safe.
+    try:
+        SCHEMA_CACHE.clear()
+    except Exception:
+        pass
+
+
+def purge_stale_browserlayers(site):
+    """Remove plone.browserlayer utilities whose interface can't be imported
+    (Broken objects) and that come from the old library.* modules."""
+    purged = []
+    try:
+        from plone.browserlayer.interfaces import ILocalBrowserLayerType
+    except Exception as exc:  # pragma: no cover
+        print("  ! could not import ILocalBrowserLayerType: %s" % exc)
+        return purged
+    sm = site.getSiteManager()
+    # Snapshot registrations first (we mutate during iteration).
+    regs = list(sm.registeredUtilities())
+    for reg in regs:
+        if reg.provided is not ILocalBrowserLayerType:
+            continue
+        iface = reg.component
+        module = getattr(iface, "__module__", "") or ""
+        name = getattr(iface, "__name__", "") or reg.name or ""
+        if module.startswith(OLD_PREFIX) or name.startswith("ILibrary"):
+            sm.unregisterUtility(
+                component=iface,
+                provided=ILocalBrowserLayerType,
+                name=reg.name,
+            )
+            purged.append((reg.name, module, name))
+    return purged
+
+
+def register_new_browserlayers(site):
+    """Run the browserlayer import step for the renamed profiles so
+    IBibliothecaCoreLayer / IBibliothecaPolicyLayer get registered."""
+    registered = []
+    setup_tool = site.portal_setup
+    for profile in (
+        "profile-bibliotheca.core:default",
+        "profile-bibliotheca.policy:default",
+    ):
+        try:
+            setup_tool.runImportStepFromProfile(profile, "browserlayer")
+            registered.append(profile)
+        except Exception as exc:
+            print("  ! browserlayer import failed for %s: %s" % (profile, exc))
+    return registered
+
+
+def main(app):
+    total_changes = 0
+    sites = list(iter_plone_sites(app))
+    if not sites:
+        print("No Plone site found under the application root.")
+        return
+    for site in sites:
+        print("=== Site: /%s ===" % site.getId())
+        setSite(site)
+
+        changed = fix_ftis(site)
+        for type_id, attr, old, new in changed:
+            print("  FTI %-20s %s: %s -> %s" % (type_id, attr, old, new))
+        if changed:
+            invalidate_schema_cache(changed)
+
+        purged = purge_stale_browserlayers(site)
+        for name, module, iface_name in purged:
+            print("  browserlayer purged: name=%r %s.%s" % (name, module, iface_name))
+
+        registered = register_new_browserlayers(site)
+        for profile in registered:
+            print("  browserlayer imported from %s" % profile)
+
+        total_changes += len(changed) + len(purged) + len(registered)
+
+    if total_changes:
+        transaction.commit()
+        print("\nCommitted %d change(s)." % total_changes)
+    else:
+        transaction.abort()
+        print("\nNothing to change.")
+
+
+main(app)  # noqa: F821  (app is injected by `bin/instance run`)

--- a/scripts/realign_profiles.py
+++ b/scripts/realign_profiles.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""Set the renamed profiles' last-applied versions (idempotent).
+
+Run with:  bin/instance run scripts/realign_profiles.py
+
+The library.* profile-version records were dropped in a first pass. This sets
+the renamed bibliotheca.* profiles to the versions the library.* profiles had
+recorded, so the add-ons show as installed and GenericSetup still offers any
+genuine pending upgrade (e.g. bibliotheca.policy 1017 -> 1018, idempotent).
+"""
+import transaction
+from zope.component.hooks import setSite
+
+# renamed profile id -> version that its library.* predecessor last recorded.
+TARGETS = {
+    "bibliotheca.core:default": ("1005",),
+    "bibliotheca.policy:default": ("1017",),
+}
+
+
+def main(app):
+    total = 0
+    for obj in app.objectValues():
+        if getattr(obj, "portal_setup", None) is None:
+            continue
+        print("=== Site: /%s ===" % obj.getId())
+        setSite(obj)
+        setup_tool = obj.portal_setup
+
+        for profile_id, version in TARGETS.items():
+            current = setup_tool.getLastVersionForProfile(profile_id)
+            if current == version:
+                print("  %-40s already %s" % (profile_id, current))
+                continue
+            setup_tool.setLastVersionForProfile(profile_id, version)
+            print("  %-40s %s -> %s" % (profile_id, current, version))
+            total += 1
+
+        print("  --- all records now ---")
+        for pid in sorted(setup_tool._profile_upgrade_versions):
+            print("    %-40s %s" % (pid, setup_tool._profile_upgrade_versions[pid]))
+
+    if total:
+        transaction.commit()
+        print("\nCommitted: set %d profile version(s)." % total)
+    else:
+        transaction.abort()
+        print("\nNothing to change.")
+
+
+main(app)  # noqa: F821  (app injected by `bin/instance run`)

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,6 +1,6 @@
 [versions]
 bibliotheca.core = 3.0.1
-bibliotheca.policy = 3.1.1
+bibliotheca.policy = 3.1.2
 
 # to avoid ModuleNotFoundError: No module named 'zc.lockfile'
 horse-with-no-namespace = 20260202.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade handling for existing installs affected by the `library.*` → `bibliotheca.*` rename, including repairing stored schema references and restoring missing browser layer bindings.
* **Chores**
  * Added maintenance tools to fix persisted rename artifacts and to realign GenericSetup profile version records across existing sites.
  * Added an upgrade step for the `bibliotheca.policy` package to apply the rename repairs in existing ZODB data.
  * Bumped `bibliotheca.policy` from 3.1.1 to 3.1.2.
* **Documentation**
  * Updated the changelog with the new maintenance/upgrade instructions, including how to run the tools via the instance command line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->