### PR TITLE
Migrate to Plone 6.2.1

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,32 @@
+name: Build and push dev image to registry
+on:
+  workflow_dispatch:
+env:
+  IMAGE_NAME: 'web/bibliotheca/mutual'
+  REGISTRY_URL: ${{ secrets.HARBOR_URL }}
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  build-push:
+    runs-on: gha-runners-smartweb
+    steps:
+      - name: Build tags
+        run: |
+          {
+            echo 'IMAGE_TAGS<<EOF'
+            echo '${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:dev'
+            echo '${{ env.REGISTRY_URL }}/${{ env.IMAGE_NAME }}:dev-${{ github.run_number }}'
+            echo EOF
+          } >> $GITHUB_ENV
+      - name: Build push and notify
+        uses: IMIO/gha/build-push-notify@v7
+        with:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_TAGS: ${{ env.IMAGE_TAGS }}
+          REGISTRY_URL: ${{ env.REGISTRY_URL}}
+          REGISTRY_USERNAME: ${{ secrets.SMARTWEB_HARBOR_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.SMARTWEB_HARBOR_PASSWORD }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ CHANGELOG
 6.1.0-8 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Migrate to Plone 6.2.1
+  [remdub]
 
 
 6.1.0-7 (2026-07-29)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ CHANGELOG
 6.1.0-8 (unreleased)
 --------------------
 
+- Remove unused version pins left over from ``pas.plugins.imio``, which was replaced
+  by ``pas.plugins.kimug``: ``authomatic``, ``pas.plugins.authomatic`` and
+  ``plone-app-changeownership``
+  [remdub]
+
 - Migrate to Plone 6.2.1
   [remdub]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM harbor.imio.be/common/plone-base:6.1.5-buildout5 AS builder
+FROM harbor.imio.be/common/plone-base:6.2.1 AS builder
 LABEL maintainer="Benoît Suttor <benoit.suttor@imio.be>"
 ENV PIP=26.1.2 \
   ZC_BUILDOUT=5.2.0 \
   SETUPTOOLS=81.0.0 \
   WHEEL=0.47.0 \
   PY_SPY=0.4.2 \
-  PLONE_MAJOR=6.1 \
-  PLONE_VERSION=6.1.5
+  PLONE_MAJOR=6.2 \
+  PLONE_VERSION=6.2.1
 
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -37,13 +37,13 @@ COPY --chown=imio scripts /plone/scripts
 RUN su -c "buildout -c prod.cfg -t 30 -N" -s /bin/sh imio
 
 
-FROM harbor.imio.be/common/plone-base:6.1.5-buildout5
+FROM harbor.imio.be/common/plone-base:6.2.1
 ENV PIP=26.1.2 \
   ZC_BUILDOUT=5.2.0 \
   SETUPTOOLS=81.0.0 \
   WHEEL=0.47.0 \
-  PLONE_MAJOR=6.1 \
-  PLONE_VERSION=6.1.5 \
+  PLONE_MAJOR=6.2 \
+  PLONE_VERSION=6.2.1 \
   HOSTNAME_HOST=local \
   PROJECT_ID=bibliotheca \
   PLONE_EXTENSION_IDS=plone.app.caching:default,plonetheme.barceloneta:default,bibliotheca.policy:default \

--- a/base.cfg
+++ b/base.cfg
@@ -8,8 +8,6 @@ parts =
     zopepy
     omelette
 
-auto-checkout +=
-    plone.formwidget.geolocation
 
 extends =
     https://dist.plone.org/release/6.2.1/versions.cfg

--- a/base.cfg
+++ b/base.cfg
@@ -41,15 +41,12 @@ environment-vars =
 
 eggs =
     Plone
-    horse-with-no-namespace
     bibliotheca.policy
     collective.preventactions
     collective.upgrade
 zcml =
     collective.preventactions
     bibliotheca.policy
-
-initialization = import horse_with_no_namespace
 
 [omelette]
 recipe = collective.recipe.omelette

--- a/base.cfg
+++ b/base.cfg
@@ -12,9 +12,9 @@ auto-checkout +=
     plone.formwidget.geolocation
 
 extends =
-    https://dist.plone.org/release/6.1.5/versions.cfg
-    https://dist.plone.org/release/6.1.5/versions-ecosystem.cfg
-    https://dist.plone.org/release/6.1.5/versions-extra.cfg
+    https://dist.plone.org/release/6.2.1/versions.cfg
+    https://dist.plone.org/release/6.2.1/versions-ecosystem.cfg
+    https://dist.plone.org/release/6.2.1/versions-extra.cfg
     sources.cfg
     versions.cfg
 

--- a/prod.cfg
+++ b/prod.cfg
@@ -10,7 +10,6 @@ parts +=
 
 auto-checkout =
     collective.upgrade
-    plone.formwidget.geolocation
     collective.preventactions
     collective.behavior.gallery
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -15,4 +15,3 @@ collective.behavior.gallery = git ${remotes:imio}/collective.behavior.gallery.gi
 collective.preventactions = git ${remotes:collective}/collective.preventactions.git pushurl=${remotes:collective_push}/collective.preventactions.git branch=plone6
 collective.upgrade = git ${remotes:collective}/collective.upgrade.git pushurl=${remotes:collective_push}/collective.upgrade.git branch=plone61
 pas.plugins.kimug = git ${remotes:imio}/pas.plugins.kimug.git pushurl=${remotes:imio_push}/pas.plugins.kimug.git
-plone.formwidget.geolocation = git ${remotes:imio}/plone.formwidget.geolocation.git pushurl=${remotes:imio_push}/plone.formwidget.geolocation.git branch=fix-geosearch

--- a/versions.cfg
+++ b/versions.cfg
@@ -2,7 +2,6 @@
 bibliotheca.core = 3.0.1
 bibliotheca.policy = 3.1.2
 
-authomatic = 1.3.0
 asttokens = 3.0.0
 collective.behavior.banner = 2.0
 collective.behavior.gallery = 1.0b1
@@ -29,12 +28,10 @@ jedi = 0.19.2
 jwcrypto = 1.5.6
 matplotlib-inline = 0.2.1
 parso = 0.8.5
-pas.plugins.authomatic = 2.0.0
 pas.plugins.kimug = 1.9.4
 pexpect = 4.9.0
 perfmetrics = 4.2.0
 ptyprocess = 0.7.0
-plone-app-changeownership = 1.0
 plone.app.drafts = 2.0.0
 plone-app-imagecropping = 3.0.3
 plone.app.themingplugins = 1.2

--- a/versions.cfg
+++ b/versions.cfg
@@ -2,13 +2,6 @@
 bibliotheca.core = 3.0.1
 bibliotheca.policy = 3.1.2
 
-# to avoid ModuleNotFoundError: No module named 'zc.lockfile'
-horse-with-no-namespace = 20260202.0
-pip = 26.1.2
-setuptools = 81.0.0
-wheel = 0.47.0
-zc.buildout = 5.2.0
-
 authomatic = 1.3.0
 asttokens = 3.0.0
 collective.behavior.banner = 2.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upgraded the application platform to Plone 6.2.1 for improved compatibility and platform support.

- **Documentation**
  - Added release notes for version 6.1.0-8, including upgrade guidance and updated package information.

- **Chores**
  - Added an on-demand development image build and publishing workflow.
  - Updated build and deployment configuration to support the new platform version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->